### PR TITLE
Fix missing key in language list

### DIFF
--- a/src/components/LanguageChoice/LanguagesList.tsx
+++ b/src/components/LanguageChoice/LanguagesList.tsx
@@ -36,9 +36,13 @@ export const LanguagesList = ({ languages, navigationCallback, type, hideSelecte
   return (
     <div className="containerLang">
       {languages.map((lang: ILanguage, index: number) => (
-        <div onMouseDown={(e) => handleClick(e, lang.langId)}>
+        <button
+          key={lang.sno}
+          type="button"
+          className={type === "modal" ? "languageListButton" : undefined}
+          onMouseDown={(e) => handleClick(e, lang.langId)}
+        >
           <label
-            key={lang.sno}
             ref={(ref) => {
               labelRefs.current[index] = ref!;
             }}
@@ -48,7 +52,7 @@ export const LanguagesList = ({ languages, navigationCallback, type, hideSelecte
             {lang.title}
             <input type="radio" checked={lang.selected} readOnly id={lang.sno.toString()} />
           </label>
-        </div>
+        </button>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- use `<button>` in `LanguagesList` instead of a `div` for accessible language option items

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68402999c6b083249445fb4e42fd87be